### PR TITLE
Add support for tailing wildcard in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ fastJson.on('spain.people[1].name', (value) => {
   console.log('spain.people[1].name ->', value);
 });
 
+// wildcard for each property name
+fastJson.on('spain.people[1].*', (value) => {
+  console.log('spain.people[1].* ->', value);
+});
+
+// wildcard for each array element
+fastJson.on('spain.people[*]', (value) => {
+  console.log('spain.people[*] ->', value);
+});
+
+// emit event when whole doc parsed
+fastJson.on('', (value) => {
+  console.log('whole doc ->', value);
+});
+
 fastJson.write(data);
 // or
 fastJson.write(new Buffer(data));

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ fastJson.on('spain.people[1].name', (value) => {
   console.log('spain.people[1].name ->', value);
 });
 
+// wildcard for property of each array element
+fastJson.on('spain.people[*].name', (value) => {
+  console.log('spain.people[*].name ->', value.toString());
+});
+
 // wildcard for each property name
 fastJson.on('spain.people[1].*', (value) => {
   console.log('spain.people[1].* ->', value);

--- a/example/usage.js
+++ b/example/usage.js
@@ -29,4 +29,19 @@ fastJson.on('spain.people[1].name', (value) => {
   console.log('spain.people[1].name ->', value);
 });
 
+// wildcard for each property name
+fastJson.on('spain.people[1].*', (value) => {
+  console.log('spain.people[1].* ->', value);
+});
+
+// wildcard for each array element
+fastJson.on('spain.people[*]', (value) => {
+  console.log('spain.people[*] ->', value);
+});
+
+// emit event when whole doc parsed
+fastJson.on('', (value) => {
+  console.log('whole doc ->', value);
+});
+
 fastJson.write(data);

--- a/example/usage.js
+++ b/example/usage.js
@@ -34,6 +34,11 @@ fastJson.on('spain.people[1].*', (value) => {
   console.log('spain.people[1].* ->', value);
 });
 
+// wildcard for property of each array element
+fastJson.on('spain.people[*].name', (value) => {
+  console.log('spain.people[*].name ->', value.toString());
+});
+
 // wildcard for each array element
 fastJson.on('spain.people[*]', (value) => {
   console.log('spain.people[*] ->', value);

--- a/lib/FastJson.js
+++ b/lib/FastJson.js
@@ -73,7 +73,7 @@ class FastJson {
 
     var parent = this._resolveParentKey(data);
     var path = this._resolvePath(parent);
-    var wild = this._resolvePathWildcard(parent);
+    var wild = this._resolveWildcardPath(parent);
 
     if (!this._subPaths.has(path) && !this._subPaths.has(wild)) {
       this._level--;
@@ -96,12 +96,12 @@ class FastJson {
 
     var parent = this._resolveParentKey(data);
     var path = this._resolvePath(parent);
-    var wild = this._resolvePathWildcard(parent);
+    var wild = this._resolveWildcardPath(parent);
 
     if (!this._subPaths.has(path) && !this._subPaths.has(wild)) {
       this._level--;
       return this._skipBlock(data, index, OPEN_BRACKET, CLOSE_BRACKET);
-    }
+  }
 
     this._stack[this._level] = {
       type: 'array',
@@ -140,6 +140,7 @@ class FastJson {
     var str = { start: index + 1, end: this._parseString(data, index) };
     var path;
     var wild;
+    var parentWild;
 
     if (this._postColon) {
       path = this._resolvePathForPrimitiveObject(data);
@@ -148,10 +149,16 @@ class FastJson {
         this._events.emit(path, data.slice(str.start, str.end));
       }
 
-      wild = this._resolvePathForPrimativeObjectWildcard(data);
+      wild = this._resolveWildcardPathForPrimativeObject(data);
 
       if (this._hasListeners(wild)) {
         this._events.emit(wild, data.slice(str.start, str.end));
+      }
+
+      parentWild = this._resolveParentWildcardPathForPrimativeObject(data);
+
+      if (this._hasListeners(parentWild)) {
+        this._events.emit(parentWild, data.slice(str.start, str.end));
       }
     } else if (frame.type === 'array') {
       path = this._resolvePathForPrimitiveArray(data);
@@ -160,7 +167,7 @@ class FastJson {
         this._events.emit(path, data.slice(str.start, str.end));
       }
 
-      wild = this._resolvePathForPrimativeArrayWildcard(data);
+      wild = this._resolveWildcardPathForPrimativeArray(data);
 
       if (this._hasListeners(wild)) {
         this._events.emit(wild, data.slice(str.start, str.end));
@@ -193,7 +200,7 @@ class FastJson {
         this._events.emit(path, data.slice(index, primEnd));
       }
 
-      wild = this._resolvePathForPrimativeObjectWildcard(data);
+      wild = this._resolveWildcardPathForPrimativeObject(data);
 
       if (this._hasListeners(wild)) {
         this._events.emit(wild, data.slice(index, primEnd));
@@ -205,7 +212,7 @@ class FastJson {
         this._events.emit(path, data.slice(index, primEnd));
       }
 
-      wild = this._resolvePathForPrimativeArrayWildcard(data);
+      wild = this._resolveWildcardPathForPrimativeArray(data);
 
       if (this._hasListeners(wild)) {
         this._events.emit(wild, data.slice(index, primEnd));
@@ -288,7 +295,7 @@ class FastJson {
     return this._stack[this._level - 1].path + '/' + parentKey;
   }
 
-  _resolvePathWildcard(parentKey) {
+  _resolveWildcardPath(parentKey) {
     if (this._level === 0) {
       return '*';
     } else if (this._level === 1) {
@@ -319,7 +326,7 @@ class FastJson {
     return this._stack[this._level].path + '/' + this._stack[this._level].index;
   }
 
-  _resolvePathForPrimativeObjectWildcard(data) {
+  _resolveWildcardPathForPrimativeObject(data) {
       if (this._level === 0) {
         return '/*';
       }
@@ -327,7 +334,16 @@ class FastJson {
       return this._stack[this._level].path + '/*';
   }
 
-  _resolvePathForPrimativeArrayWildcard(data) {
+  _resolveParentWildcardPathForPrimativeObject(data) {
+      if (this._level >= 1) {
+          return this._stack[this._level - 1].path + '/*/' +
+              this._toString(data, this._lastString.start, this._lastString.end);
+      }
+
+      return '#invalidpath';
+  }
+
+  _resolveWildcardPathForPrimativeArray(data) {
       if (this._level === 0) {
         return '/*';
       }

--- a/lib/FastJson.js
+++ b/lib/FastJson.js
@@ -73,8 +73,9 @@ class FastJson {
 
     var parent = this._resolveParentKey(data);
     var path = this._resolvePath(parent);
+    var wild = this._resolvePathWildcard(parent);
 
-    if (!this._subPaths.has(path)) {
+    if (!this._subPaths.has(path) && !this._subPaths.has(wild)) {
       this._level--;
       return this._skipBlock(data, index, OPEN_BRACE, CLOSE_BRACE);
     }
@@ -87,7 +88,6 @@ class FastJson {
     };
 
     this._postColon = false;
-
     return index;
   }
 
@@ -96,8 +96,9 @@ class FastJson {
 
     var parent = this._resolveParentKey(data);
     var path = this._resolvePath(parent);
+    var wild = this._resolvePathWildcard(parent);
 
-    if (!this._subPaths.has(path)) {
+    if (!this._subPaths.has(path) && !this._subPaths.has(wild)) {
       this._level--;
       return this._skipBlock(data, index, OPEN_BRACKET, CLOSE_BRACKET);
     }
@@ -119,9 +120,16 @@ class FastJson {
     var frame = this._stack[this._level];
     frame.end = index;
 
+    var wild = frame.path.substring(0, frame.path.lastIndexOf('/') + 1) + '*';
+
     if (this._hasListeners(frame.path)) {
       var result = data.slice(frame.start, frame.end + 1);
       this._events.emit(frame.path, result);
+    }
+
+    if (this._hasListeners(wild)) {
+      var result = data.slice(frame.start, frame.end + 1);
+      this._events.emit(wild, result);
     }
 
     this._level--;
@@ -131,6 +139,7 @@ class FastJson {
     var frame = this._stack[this._level];
     var str = { start: index + 1, end: this._parseString(data, index) };
     var path;
+    var wild;
 
     if (this._postColon) {
       path = this._resolvePathForPrimitiveObject(data);
@@ -138,11 +147,23 @@ class FastJson {
       if (this._hasListeners(path)) {
         this._events.emit(path, data.slice(str.start, str.end));
       }
+
+      wild = this._resolvePathForPrimativeObjectWildcard(data);
+
+      if (this._hasListeners(wild)) {
+        this._events.emit(wild, data.slice(str.start, str.end));
+      }
     } else if (frame.type === 'array') {
       path = this._resolvePathForPrimitiveArray(data);
 
       if (this._hasListeners(path)) {
         this._events.emit(path, data.slice(str.start, str.end));
+      }
+
+      wild = this._resolvePathForPrimativeArrayWildcard(data);
+
+      if (this._hasListeners(wild)) {
+        this._events.emit(wild, data.slice(str.start, str.end));
       }
     }
 
@@ -163,6 +184,7 @@ class FastJson {
     var frame = this._stack[this._level];
     var primEnd = this._parsePrimitive(data, index);
     var path;
+    var wild;
 
     if (this._postColon) {
       path = this._resolvePathForPrimitiveObject(data);
@@ -170,11 +192,23 @@ class FastJson {
       if (this._hasListeners(path)) {
         this._events.emit(path, data.slice(index, primEnd));
       }
+
+      wild = this._resolvePathForPrimativeObjectWildcard(data);
+
+      if (this._hasListeners(wild)) {
+        this._events.emit(wild, data.slice(index, primEnd));
+      }
     } else if (frame.type === 'array') {
       path = this._resolvePathForPrimitiveArray(data);
 
       if (this._hasListeners(path)) {
         this._events.emit(path, data.slice(index, primEnd));
+      }
+
+      wild = this._resolvePathForPrimativeArrayWildcard(data);
+
+      if (this._hasListeners(wild)) {
+        this._events.emit(wild, data.slice(index, primEnd));
       }
     }
 
@@ -254,6 +288,16 @@ class FastJson {
     return this._stack[this._level - 1].path + '/' + parentKey;
   }
 
+  _resolvePathWildcard(parentKey) {
+    if (this._level === 0) {
+      return '*';
+    } else if (this._level === 1) {
+      return this._stack[this._level - 1].path + '*';
+    }
+
+    return this._stack[this._level - 1].path + '/*';
+  }
+
   _hasListeners(processedPath) {
     return this._events.listenerCount(processedPath) > 0;
   }
@@ -273,6 +317,22 @@ class FastJson {
     }
 
     return this._stack[this._level].path + '/' + this._stack[this._level].index;
+  }
+
+  _resolvePathForPrimativeObjectWildcard(data) {
+      if (this._level === 0) {
+        return '/*';
+      }
+
+      return this._stack[this._level].path + '/*';
+  }
+
+  _resolvePathForPrimativeArrayWildcard(data) {
+      if (this._level === 0) {
+        return '/*';
+      }
+
+      return this._stack[this._level].path + '/*';
   }
 
   _processPath(path) {


### PR DESCRIPTION
I updated the readme and examples in an attempt to show what this does.

I needed the ability to parse a response with a large embedded array in it, and also do some follow up processing once the whole response has been parsed. It was not feasible to subscribe to every array index. I needed a wildcard for each array element.

While I was in there, I did the same for object values.

With this change, I should be able to start processing the elements in the array very quickly. Nice library!